### PR TITLE
Fix git clone url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Clone this directory, then run ```python setup.py develop```
 ### Better
 
 ```
-git clone git@github.com:dz0ny/leapcast.git
+git clone https://github.com/dz0ny/leapcast.git
 cd ./leapcast
 sudo apt-get install virtualenvwrapper python-pip
 mkvirtualenv leapcast


### PR DESCRIPTION
The git url in the README was pointed at the authenticated
read/write endpoint which you can only clone from if you have
commit access.
