### PR TITLE
Warn and exit when running inside tmux on OS X

### DIFF
--- a/leapcast/__main__.py
+++ b/leapcast/__main__.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 import threading
 import signal
 import logging
+import sys
+from os import environ
 
 from twisted.internet import reactor
 import tornado.ioloop
@@ -63,6 +65,11 @@ class HTTPThread(object):
 def main():
     parse_cmd()
     logging.basicConfig(level=Environment.verbosity)
+
+    if sys.platform == 'darwin' and environ.get('TMUX') is not None:
+        logger.error('Running Chrome inside tmux on OS X might cause problems.'
+                     ' Please start leapcast outside tmux.')
+        sys.exit(1)
 
     server = HTTPThread()
     server.start()


### PR DESCRIPTION
tmux loses access to its original namespace on OS X which causes Chrome to
crash.

See https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard#interaction-with-tmux
and http://savanne.be/804-running-karma-and-chrome-under-tmux-on-osx

Can be reproduced with the Google Music app. Chrome will then display the "Aw snap" crashed tab message.
