### PR TITLE
with --debug, args.d is not defined anymore

### DIFF
--- a/leapcast/environment.py
+++ b/leapcast/environment.py
@@ -98,9 +98,6 @@ def parse_cmd():
     if args.apps:
         Environment.apps = args.apps
 
-    if args.d:
-        Environment.verbosity = logging.DEBUG
-
     generate_uuid()
 
 


### PR DESCRIPTION
May well be my fault with all the changes in the last days and me trying to keep my version up to date. If so, sorry for that!
