### PR TITLE
Fix response codes for addresses not present in ips.

### DIFF
--- a/leapcast/services/dial.py
+++ b/leapcast/services/dial.py
@@ -38,29 +38,29 @@ class DeviceHandler(tornado.web.RequestHandler):
     </root>'''
 
     def get(self):
-        if ((len(Environment.ips) == 0) | (self.request.remote_ip in Environment.ips)):
-            if self.request.uri == "/apps":
-                for app, astatus in Environment.global_status.items():
-                    if astatus["state"] == "running":
-                        self.redirect("/apps/%s" % app)
-                self.set_status(204)
-                self.set_header(
-                    "Access-Control-Allow-Method", "GET, POST, DELETE, OPTIONS")
-                self.set_header("Access-Control-Expose-Headers", "Location")
-            else:
-                self.set_header(
-                    "Access-Control-Allow-Method", "GET, POST, DELETE, OPTIONS")
-                self.set_header("Access-Control-Expose-Headers", "Location")
-                self.add_header(
-                    "Application-URL", "http://%s/apps" % self.request.host)
-                self.set_header("Content-Type", "application/xml")
-                self.write(render(self.device).generate(
-                    friendlyName=Environment.friendlyName,
-                    uuid=Environment.uuid,
-                    path="http://%s" % self.request.host)
-                )
+        if Environment.ips and self.request.remote_ip not in Environment.ips:
+            raise tornado.web.HTTPError(403)
+
+        if self.request.uri == "/apps":
+            for app, astatus in Environment.global_status.items():
+                if astatus["state"] == "running":
+                    self.redirect("/apps/%s" % app)
+            self.set_status(204)
+            self.set_header(
+                "Access-Control-Allow-Method", "GET, POST, DELETE, OPTIONS")
+            self.set_header("Access-Control-Expose-Headers", "Location")
         else:
-            tornado.web.HTTPError(404)
+            self.set_header(
+                "Access-Control-Allow-Method", "GET, POST, DELETE, OPTIONS")
+            self.set_header("Access-Control-Expose-Headers", "Location")
+            self.add_header(
+                "Application-URL", "http://%s/apps" % self.request.host)
+            self.set_header("Content-Type", "application/xml")
+            self.write(render(self.device).generate(
+                friendlyName=Environment.friendlyName,
+                uuid=Environment.uuid,
+                path="http://%s" % self.request.host)
+            )
 
 
 class ChannelFactory(tornado.web.RequestHandler):


### PR DESCRIPTION
Currently ip's not in the ip's list, get a 200 with zero-length reply.  This commit makes leapcast return a 403 instead.

Also update the logic to use implicit boolean evaluation, invert the expression, and raise the HTTPError (instead of discarding it)
