### PR TITLE
disable websocket same-origin protection

### DIFF
--- a/leapcast/services/leap.py
+++ b/leapcast/services/leap.py
@@ -16,6 +16,7 @@ from leapcast.environment import Environment
 
 logger = logging.getLogger('Environment')
 
+
 class LEAPserver(object):
     def start(self):
         logger.info('Starting LEAP server')
@@ -60,8 +61,7 @@ class LEAPserver(object):
         for app in data['applications']:
             name = app['app_id'].encode('utf-8')
             if 'url' not in app:
-                logger.warning('Didn\'t add %s because it has no URL!' %
-                                name)
+                logger.warning('Didn\'t add %s because it has no URL!' % name)
                 continue
             logger.info('Added %s app' % name)
             url = app['url']

--- a/leapcast/services/websocket.py
+++ b/leapcast/services/websocket.py
@@ -155,6 +155,9 @@ class ServiceChannel(tornado.websocket.WebSocketHandler):
         while len(self.buf) > 0:
             self.reply(self.buf.pop())
 
+    def check_origin(self, origin):
+        return True
+
     def on_message(self, message):
         cmd = json.loads(message)
         if cmd["type"] == "REGISTER":
@@ -212,6 +215,9 @@ class WSC(tornado.websocket.WebSocketHandler):
 
         logging.info("%s opened %s" %
                      (self.cname, self.request.uri))
+
+    def check_origin(self, origin):
+        return True
 
     def on_message(self, message):
         if Environment.verbosity is logging.DEBUG:
@@ -328,6 +334,9 @@ class CastPlatform(tornado.websocket.WebSocketHandler):
     Device control:
 
     '''
+
+    def check_origin(self, origin):
+        return True
 
     def on_message(self, message):
         if Environment.verbosity is logging.DEBUG:


### PR DESCRIPTION
This only applies to tornado 4+, when same-origin checking was turned on by default.

I originally noticed this in the logs when looking into #120, but fixing it didn't fix my problem.