### PR TITLE
Fix invalid json

### DIFF
--- a/leapcast/services/dial.py
+++ b/leapcast/services/dial.py
@@ -75,7 +75,7 @@ class SetupHandler(tornado.web.RequestHandler):
         "connected":true,
         "detail":{
             "locale":{"display_string":"English (United States)"},
-            "timezone":{"display_string":"America/Los Angeles",offset:-480}
+            "timezone":{"display_string":"America/Los Angeles","offset":-480}
         },
         "has_update":false,
         "hdmi_control":true,


### PR DESCRIPTION
Testing the API on [Advanced REST client](https://chrome.google.com/webstore/detail/advanced-rest-client/hgmloofddffdnphfgcellkdfbfbjeloo) I got an error with JSON response.

This change fix this issue over ARC and [JSONLint](http://jsonlint.com/).